### PR TITLE
fix: update type import for plantaeFilter in HTMLElement interface

### DIFF
--- a/src/types/plantae-filter.d.ts
+++ b/src/types/plantae-filter.d.ts
@@ -1,7 +1,5 @@
-import type { PlantaeFilter } from '../components/plantae-filter';
-
 declare global {
     interface HTMLElement {
-        plantaeFilter?: PlantaeFilter;
+        plantaeFilter?: import('../components/plantae-filter').PlantaeFilter;
     }
 }


### PR DESCRIPTION
Update the type import for plantaeFilter to ensure proper referencing in the HTMLElement interface.