### PR TITLE
chore: add build step before npm publish in workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,6 +20,8 @@ jobs:
 
       - run: npm ci
 
+      - run: npm run build
+
       - run: npm publish --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Include a build step in the workflow prior to publishing to ensure the package is properly built.