### PR TITLE
chore: update workflow trigger to use release events

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,9 +1,8 @@
 name: Publish to NPM
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [created]
 
 jobs:
   publish:


### PR DESCRIPTION
Change the workflow trigger to activate on release events instead of tag pushes.