### PR TITLE
Update workflow trigger for NPM publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,8 +1,9 @@
 name: Publish to NPM
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - 'v*'
 
 jobs:
   publish:


### PR DESCRIPTION
Change the workflow trigger to publish on version tag pushes instead of release creation.