### PR TITLE
Update workflow to trigger on published releases

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,9 +1,8 @@
 name: Publish to NPM
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
 
 jobs:
   publish:


### PR DESCRIPTION
Change the workflow to trigger on published releases instead of tag pushes.