### PR TITLE
Update workflows to trigger NPM publish on repository dispatch

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,8 +1,8 @@
 name: Publish to NPM
 
 on:
-  release:
-    types: [published]
+  repository_dispatch:
+    types: [trigger-publish]
 
 jobs:
   publish:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,3 +13,13 @@ jobs:
         id: release
         with:
           release-type: node
+
+      # Chama o outro workflow após o release ser publicado
+      - name: Trigger publish workflow
+        if: steps.release.outputs.release_created == 'true'
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            https://api.github.com/repos/${{ github.repository }}/dispatches \
+            -d '{"event_type":"trigger-publish"}'


### PR DESCRIPTION
Change the workflow trigger from release events to repository dispatch events, allowing for more flexible control over NPM publishing.