### PR TITLE
Replace curl with repository-dispatch action for npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,6 +1,9 @@
 name: Publish to NPM
 
 on:
+  release:
+    types: [published]
+
   repository_dispatch:
     types: [trigger-publish]
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,12 +14,9 @@ jobs:
         with:
           release-type: node
 
-      # Chama o outro workflow após o release ser publicado
       - name: Trigger publish workflow
         if: steps.release.outputs.release_created == 'true'
-        run: |
-          curl -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            https://api.github.com/repos/${{ github.repository }}/dispatches \
-            -d '{"event_type":"trigger-publish"}'
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: trigger-publish


### PR DESCRIPTION
Replace the curl command with the repository-dispatch action for triggering npm publish and add a manual trigger for releases.