### PR TITLE
fix(deps): resolve all Dependabot security alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
         "": {
             "name": "@plantae-tech/plantae-filter",
             "version": "0.3.4",
+            "license": "MIT",
             "dependencies": {
                 "clusterize.js": "^1.0.0",
                 "fuse.js": "^7.1.0"
@@ -735,46 +736,46 @@
             }
         },
         "node_modules/@microsoft/api-extractor": {
-            "version": "7.52.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.52.1.tgz",
-            "integrity": "sha512-m3I5uAwE05orsu3D1AGyisX5KxsgVXB+U4bWOOaX/Z7Ftp/2Cy41qsNhO6LPvSxHBaapyser5dVorF1t5M6tig==",
+            "version": "7.58.9",
+            "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.58.9.tgz",
+            "integrity": "sha512-S2UF4yza5GoxCmf7hJQNxJNZN9ltOVuOQv8Dy+Z21aol5ERoBNMdWcQHm4MJMPPItW4H/4rZD906iaf4mUojJA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@microsoft/api-extractor-model": "7.30.4",
-                "@microsoft/tsdoc": "~0.15.1",
-                "@microsoft/tsdoc-config": "~0.17.1",
-                "@rushstack/node-core-library": "5.12.0",
-                "@rushstack/rig-package": "0.5.3",
-                "@rushstack/terminal": "0.15.1",
-                "@rushstack/ts-command-line": "4.23.6",
-                "lodash": "~4.17.15",
-                "minimatch": "~3.0.3",
+                "@microsoft/api-extractor-model": "7.33.8",
+                "@microsoft/tsdoc": "~0.16.0",
+                "@microsoft/tsdoc-config": "~0.18.1",
+                "@rushstack/node-core-library": "5.23.1",
+                "@rushstack/rig-package": "0.7.3",
+                "@rushstack/terminal": "0.24.0",
+                "@rushstack/ts-command-line": "5.3.10",
+                "diff": "~8.0.2",
+                "minimatch": "10.2.3",
                 "resolve": "~1.22.1",
-                "semver": "~7.5.4",
+                "semver": "~7.7.4",
                 "source-map": "~0.6.1",
-                "typescript": "5.8.2"
+                "typescript": "5.9.3"
             },
             "bin": {
                 "api-extractor": "bin/api-extractor"
             }
         },
         "node_modules/@microsoft/api-extractor-model": {
-            "version": "7.30.4",
-            "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.30.4.tgz",
-            "integrity": "sha512-RobC0gyVYsd2Fao9MTKOfTdBm41P/bCMUmzS5mQ7/MoAKEqy0FOBph3JOYdq4X4BsEnMEiSHc+0NUNmdzxCpjA==",
+            "version": "7.33.8",
+            "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.33.8.tgz",
+            "integrity": "sha512-aIcoQggPyer3B6Ze3usz0YWC/oBwUHfRH5ETUsr+oT2BRA6SfTJl7IKPcPZkX4UR+PohowzW4uMxsvjrn8vm+w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@microsoft/tsdoc": "~0.15.1",
-                "@microsoft/tsdoc-config": "~0.17.1",
-                "@rushstack/node-core-library": "5.12.0"
+                "@microsoft/tsdoc": "~0.16.0",
+                "@microsoft/tsdoc-config": "~0.18.1",
+                "@rushstack/node-core-library": "5.23.1"
             }
         },
         "node_modules/@microsoft/api-extractor/node_modules/typescript": {
-            "version": "5.8.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-            "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -786,21 +787,21 @@
             }
         },
         "node_modules/@microsoft/tsdoc": {
-            "version": "0.15.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
-            "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
+            "version": "0.16.0",
+            "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+            "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@microsoft/tsdoc-config": {
-            "version": "0.17.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.17.1.tgz",
-            "integrity": "sha512-UtjIFe0C6oYgTnad4q1QP4qXwLhe6tIpNTRStJ2RZEPIkqQPREAwE5spzVxsdn9UaEMUqhh0AqSx3X4nWAKXWw==",
+            "version": "0.18.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.18.1.tgz",
+            "integrity": "sha512-9brPoVdfN9k9g0dcWkFeA7IH9bbcttzDJlXvkf8b2OBzd5MueR1V2wkKBL0abn0otvmkHJC6aapBOTJDDeMCZg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@microsoft/tsdoc": "0.15.1",
-                "ajv": "~8.12.0",
+                "@microsoft/tsdoc": "0.16.0",
+                "ajv": "~8.18.0",
                 "jju": "~1.4.0",
                 "resolve": "~1.22.2"
             }
@@ -867,9 +868,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.36.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.36.0.tgz",
-            "integrity": "sha512-jgrXjjcEwN6XpZXL0HUeOVGfjXhPyxAbbhD0BlXUB+abTOpbPiN5Wb3kOT7yb+uEtATNYF5x5gIfwutmuBA26w==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+            "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
             "cpu": [
                 "arm"
             ],
@@ -881,9 +882,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.36.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.36.0.tgz",
-            "integrity": "sha512-NyfuLvdPdNUfUNeYKUwPwKsE5SXa2J6bCt2LdB/N+AxShnkpiczi3tcLJrm5mA+eqpy0HmaIY9F6XCa32N5yzg==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+            "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
             "cpu": [
                 "arm64"
             ],
@@ -895,9 +896,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.36.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.36.0.tgz",
-            "integrity": "sha512-JQ1Jk5G4bGrD4pWJQzWsD8I1n1mgPXq33+/vP4sk8j/z/C2siRuxZtaUA7yMTf71TCZTZl/4e1bfzwUmFb3+rw==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+            "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
             "cpu": [
                 "arm64"
             ],
@@ -909,9 +910,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.36.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.36.0.tgz",
-            "integrity": "sha512-6c6wMZa1lrtiRsbDziCmjE53YbTkxMYhhnWnSW8R/yqsM7a6mSJ3uAVT0t8Y/DGt7gxUWYuFM4bwWk9XCJrFKA==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+            "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
             "cpu": [
                 "x64"
             ],
@@ -923,9 +924,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.36.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.36.0.tgz",
-            "integrity": "sha512-KXVsijKeJXOl8QzXTsA+sHVDsFOmMCdBRgFmBb+mfEb/7geR7+C8ypAml4fquUt14ZyVXaw2o1FWhqAfOvA4sg==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+            "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
             "cpu": [
                 "arm64"
             ],
@@ -937,9 +938,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.36.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.36.0.tgz",
-            "integrity": "sha512-dVeWq1ebbvByI+ndz4IJcD4a09RJgRYmLccwlQ8bPd4olz3Y213uf1iwvc7ZaxNn2ab7bjc08PrtBgMu6nb4pQ==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+            "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
             "cpu": [
                 "x64"
             ],
@@ -951,9 +952,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.36.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.36.0.tgz",
-            "integrity": "sha512-bvXVU42mOVcF4le6XSjscdXjqx8okv4n5vmwgzcmtvFdifQ5U4dXFYaCB87namDRKlUL9ybVtLQ9ztnawaSzvg==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+            "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
             "cpu": [
                 "arm"
             ],
@@ -965,9 +966,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.36.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.36.0.tgz",
-            "integrity": "sha512-JFIQrDJYrxOnyDQGYkqnNBtjDwTgbasdbUiQvcU8JmGDfValfH1lNpng+4FWlhaVIR4KPkeddYjsVVbmJYvDcg==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+            "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
             "cpu": [
                 "arm"
             ],
@@ -979,9 +980,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.36.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.36.0.tgz",
-            "integrity": "sha512-KqjYVh3oM1bj//5X7k79PSCZ6CvaVzb7Qs7VMWS+SlWB5M8p3FqufLP9VNp4CazJ0CsPDLwVD9r3vX7Ci4J56A==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+            "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
             "cpu": [
                 "arm64"
             ],
@@ -993,9 +994,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.36.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.36.0.tgz",
-            "integrity": "sha512-QiGnhScND+mAAtfHqeT+cB1S9yFnNQ/EwCg5yE3MzoaZZnIV0RV9O5alJAoJKX/sBONVKeZdMfO8QSaWEygMhw==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+            "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1006,10 +1007,10 @@
                 "linux"
             ]
         },
-        "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-            "version": "4.36.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.36.0.tgz",
-            "integrity": "sha512-1ZPyEDWF8phd4FQtTzMh8FQwqzvIjLsl6/84gzUxnMNFBtExBtpL51H67mV9xipuxl1AEAerRBgBwFNpkw8+Lg==",
+        "node_modules/@rollup/rollup-linux-loong64-gnu": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+            "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
             "cpu": [
                 "loong64"
             ],
@@ -1020,10 +1021,38 @@
                 "linux"
             ]
         },
-        "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-            "version": "4.36.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.36.0.tgz",
-            "integrity": "sha512-VMPMEIUpPFKpPI9GZMhJrtu8rxnp6mJR3ZzQPykq4xc2GmdHj3Q4cA+7avMyegXy4n1v+Qynr9fR88BmyO74tg==",
+        "node_modules/@rollup/rollup-linux-loong64-musl": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+            "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+            "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-musl": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+            "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
             "cpu": [
                 "ppc64"
             ],
@@ -1035,9 +1064,23 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.36.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.36.0.tgz",
-            "integrity": "sha512-ttE6ayb/kHwNRJGYLpuAvB7SMtOeQnVXEIpMtAvx3kepFQeowVED0n1K9nAdraHUPJ5hydEMxBpIR7o4nrm8uA==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+            "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-musl": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+            "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
             "cpu": [
                 "riscv64"
             ],
@@ -1049,9 +1092,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.36.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.36.0.tgz",
-            "integrity": "sha512-4a5gf2jpS0AIe7uBjxDeUMNcFmaRTbNv7NxI5xOCs4lhzsVyGR/0qBXduPnoWf6dGC365saTiwag8hP1imTgag==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+            "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
             "cpu": [
                 "s390x"
             ],
@@ -1063,9 +1106,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.36.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.36.0.tgz",
-            "integrity": "sha512-5KtoW8UWmwFKQ96aQL3LlRXX16IMwyzMq/jSSVIIyAANiE1doaQsx/KRyhAvpHlPjPiSU/AYX/8m+lQ9VToxFQ==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+            "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
             "cpu": [
                 "x64"
             ],
@@ -1077,9 +1120,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.36.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.36.0.tgz",
-            "integrity": "sha512-sycrYZPrv2ag4OCvaN5js+f01eoZ2U+RmT5as8vhxiFz+kxwlHrsxOwKPSA8WyS+Wc6Epid9QeI/IkQ9NkgYyQ==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+            "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
             "cpu": [
                 "x64"
             ],
@@ -1090,10 +1133,38 @@
                 "linux"
             ]
         },
+        "node_modules/@rollup/rollup-openbsd-x64": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+            "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-openharmony-arm64": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+            "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ]
+        },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.36.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.36.0.tgz",
-            "integrity": "sha512-qbqt4N7tokFwwSVlWDsjfoHgviS3n/vZ8LK0h1uLG9TYIRuUTJC88E1xb3LM2iqZ/WTqNQjYrtmtGmrmmawB6A==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+            "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
             "cpu": [
                 "arm64"
             ],
@@ -1105,9 +1176,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.36.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.36.0.tgz",
-            "integrity": "sha512-t+RY0JuRamIocMuQcfwYSOkmdX9dtkr1PbhKW42AMvaDQa+jOdpUYysroTF/nuPpAaQMWp7ye+ndlmmthieJrQ==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+            "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
             "cpu": [
                 "ia32"
             ],
@@ -1118,10 +1189,24 @@
                 "win32"
             ]
         },
+        "node_modules/@rollup/rollup-win32-x64-gnu": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+            "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.36.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.36.0.tgz",
-            "integrity": "sha512-aRXd7tRZkWLqGbChgcMMDEHjOKudo1kChb1Jt1IfR8cY/KIpgNviLeJy5FUb9IpSuQj8dU2fAYNMPW/hLKOSTw==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+            "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
             "cpu": [
                 "x64"
             ],
@@ -1133,20 +1218,20 @@
             ]
         },
         "node_modules/@rushstack/node-core-library": {
-            "version": "5.12.0",
-            "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.12.0.tgz",
-            "integrity": "sha512-QSwwzgzWoil1SCQse+yCHwlhRxNv2dX9siPnAb9zR/UmMhac4mjMrlMZpk64BlCeOFi1kJKgXRkihSwRMbboAQ==",
+            "version": "5.23.1",
+            "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.23.1.tgz",
+            "integrity": "sha512-wlKmIKIYCKuCASbITvOxLZXepPbwXvrv7S6ig6XNWFchSyhL/E2txmVXspHY49Wu2dzf7nI27a2k/yV5BA3EiA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ajv": "~8.13.0",
+                "ajv": "~8.18.0",
                 "ajv-draft-04": "~1.0.0",
                 "ajv-formats": "~3.0.1",
                 "fs-extra": "~11.3.0",
                 "import-lazy": "~4.0.0",
                 "jju": "~1.4.0",
                 "resolve": "~1.22.1",
-                "semver": "~7.5.4"
+                "semver": "~7.7.4"
             },
             "peerDependencies": {
                 "@types/node": "*"
@@ -1157,42 +1242,41 @@
                 }
             }
         },
-        "node_modules/@rushstack/node-core-library/node_modules/ajv": {
-            "version": "8.13.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
-            "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
+        "node_modules/@rushstack/problem-matcher": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@rushstack/problem-matcher/-/problem-matcher-0.2.1.tgz",
+            "integrity": "sha512-gulfhBs6n+I5b7DvjKRfhMGyUejtSgOHTclF/eONr8hcgF1APEDjhxIsfdUYYMzC3rvLwGluqLjbwCFZ8nxrog==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2",
-                "uri-js": "^4.4.1"
+            "peerDependencies": {
+                "@types/node": "*"
             },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@rushstack/rig-package": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.5.3.tgz",
-            "integrity": "sha512-olzSSjYrvCNxUFZowevC3uz8gvKr3WTpHQ7BkpjtRpA3wK+T0ybep/SRUMfr195gBzJm5gaXw0ZMgjIyHqJUow==",
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.7.3.tgz",
+            "integrity": "sha512-aAA518n6wxxjCfnTAOjQnm7ngNE0FVHxHAw2pxKlIhxrMn0XQjGcXKF0oKWpjBgJOmsaJpVob/v+zr3zxgPWuA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "resolve": "~1.22.1",
-                "strip-json-comments": "~3.1.1"
+                "jju": "~1.4.0",
+                "resolve": "~1.22.1"
             }
         },
         "node_modules/@rushstack/terminal": {
-            "version": "0.15.1",
-            "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.15.1.tgz",
-            "integrity": "sha512-3vgJYwumcjoDOXU3IxZfd616lqOdmr8Ezj4OWgJZfhmiBK4Nh7eWcv8sU8N/HdzXcuHDXCRGn/6O2Q75QvaZMA==",
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.24.0.tgz",
+            "integrity": "sha512-8ZQS4MMaGsv27EXCBiH7WMPkRZrffeDoIevs6z9TM5dzqiY6+Hn4evfK/G+gvgBTjfvfkHIZPQQmalmI2sM4TQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@rushstack/node-core-library": "5.12.0",
+                "@rushstack/node-core-library": "5.23.1",
+                "@rushstack/problem-matcher": "0.2.1",
                 "supports-color": "~8.1.1"
             },
             "peerDependencies": {
@@ -1205,13 +1289,13 @@
             }
         },
         "node_modules/@rushstack/ts-command-line": {
-            "version": "4.23.6",
-            "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.23.6.tgz",
-            "integrity": "sha512-7WepygaF3YPEoToh4MAL/mmHkiIImQq3/uAkQX46kVoKTNOOlCtFGyNnze6OYuWw2o9rxsyrHVfIBKxq/am2RA==",
+            "version": "5.3.10",
+            "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.3.10.tgz",
+            "integrity": "sha512-fwI076HYknC0IrMXdY6UmjDv+PH7NHhNJX3/pY2UblSE5XrXgndXZPiOe/6ZtuFpn6DvVDVNhtkIzQ+Qu/MhVQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@rushstack/terminal": "0.15.1",
+                "@rushstack/terminal": "0.24.0",
                 "@types/argparse": "1.0.38",
                 "argparse": "~1.0.9",
                 "string-argv": "~0.3.1"
@@ -1320,34 +1404,41 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@types/estree": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-            "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@types/node": {
-            "version": "22.13.10",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
-            "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
+        "node_modules/@types/estree": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+            "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
             "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "undici-types": "~6.20.0"
-            }
+            "license": "MIT"
         },
         "node_modules/@vitest/expect": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.0.9.tgz",
-            "integrity": "sha512-5eCqRItYgIML7NNVgJj6TVCmdzE7ZVgJhruW0ziSQV4V7PvLkDL1bBkBdcTs/VuIz0IxPb5da1IDSqc1TR9eig==",
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+            "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "3.0.9",
-                "@vitest/utils": "3.0.9",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "3.2.6",
+                "@vitest/utils": "3.2.6",
                 "chai": "^5.2.0",
                 "tinyrainbow": "^2.0.0"
             },
@@ -1356,13 +1447,13 @@
             }
         },
         "node_modules/@vitest/mocker": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.0.9.tgz",
-            "integrity": "sha512-ryERPIBOnvevAkTq+L1lD+DTFBRcjueL9lOUfXsLfwP92h4e+Heb+PjiqS3/OURWPtywfafK0kj++yDFjWUmrA==",
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+            "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "3.0.9",
+                "@vitest/spy": "3.2.6",
                 "estree-walker": "^3.0.3",
                 "magic-string": "^0.30.17"
             },
@@ -1371,7 +1462,7 @@
             },
             "peerDependencies": {
                 "msw": "^2.4.9",
-                "vite": "^5.0.0 || ^6.0.0"
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
             },
             "peerDependenciesMeta": {
                 "msw": {
@@ -1393,9 +1484,9 @@
             }
         },
         "node_modules/@vitest/pretty-format": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.0.9.tgz",
-            "integrity": "sha512-OW9F8t2J3AwFEwENg3yMyKWweF7oRJlMyHOMIhO5F3n0+cgQAJZBjNgrF8dLwFTEXl5jUqBLXd9QyyKv8zEcmA==",
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+            "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1406,27 +1497,28 @@
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.0.9.tgz",
-            "integrity": "sha512-NX9oUXgF9HPfJSwl8tUZCMP1oGx2+Sf+ru6d05QjzQz4OwWg0psEzwY6VexP2tTHWdOkhKHUIZH+fS6nA7jfOw==",
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+            "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/utils": "3.0.9",
-                "pathe": "^2.0.3"
+                "@vitest/utils": "3.2.6",
+                "pathe": "^2.0.3",
+                "strip-literal": "^3.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/snapshot": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.0.9.tgz",
-            "integrity": "sha512-AiLUiuZ0FuA+/8i19mTYd+re5jqjEc2jZbgJ2up0VY0Ddyyxg/uUtBDpIFAy4uzKaQxOW8gMgBdAJJ2ydhu39A==",
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+            "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "3.0.9",
+                "@vitest/pretty-format": "3.2.6",
                 "magic-string": "^0.30.17",
                 "pathe": "^2.0.3"
             },
@@ -1435,27 +1527,27 @@
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.0.9.tgz",
-            "integrity": "sha512-/CcK2UDl0aQ2wtkp3YVWldrpLRNCfVcIOFGlVGKO4R5eajsH393Z1yiXLVQ7vWsj26JOEjeZI0x5sm5P4OGUNQ==",
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+            "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "tinyspy": "^3.0.2"
+                "tinyspy": "^4.0.3"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.0.9.tgz",
-            "integrity": "sha512-ilHM5fHhZ89MCp5aAaM9uhfl1c2JdxVxl3McqsdVyVNN6JffnEen8UMCdRTzOhGXNQGo5GNL9QugHrz727Wnng==",
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+            "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "3.0.9",
-                "loupe": "^3.1.3",
+                "@vitest/pretty-format": "3.2.6",
+                "loupe": "^3.1.4",
                 "tinyrainbow": "^2.0.0"
             },
             "funding": {
@@ -1552,10 +1644,17 @@
                 }
             }
         },
+        "node_modules/@vue/language-core/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@vue/language-core/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1563,13 +1662,13 @@
             }
         },
         "node_modules/@vue/language-core/node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -1609,16 +1708,16 @@
             }
         },
         "node_modules/ajv": {
-            "version": "8.12.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-            "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+            "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "fast-deep-equal": "^3.1.1",
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
                 "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2",
-                "uri-js": "^4.2.2"
+                "require-from-string": "^2.0.2"
             },
             "funding": {
                 "type": "github",
@@ -1706,9 +1805,9 @@
             }
         },
         "node_modules/anymatch/node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1756,11 +1855,14 @@
             "license": "MIT"
         },
         "node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
         },
         "node_modules/binary-extensions": {
             "version": "2.3.0",
@@ -1776,14 +1878,16 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
             }
         },
         "node_modules/braces": {
@@ -1831,9 +1935,9 @@
             }
         },
         "node_modules/chai": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
-            "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+            "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1844,7 +1948,7 @@
                 "pathval": "^2.0.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/chalk": {
@@ -1878,9 +1982,9 @@
             }
         },
         "node_modules/check-error": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
-            "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+            "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1965,13 +2069,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/concat-map": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/confbox": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.1.tgz",
@@ -2022,9 +2119,9 @@
             "license": "MIT"
         },
         "node_modules/debug": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-            "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2074,6 +2171,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/diff": {
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+            "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.3.1"
             }
         },
         "node_modules/dom-accessibility-api": {
@@ -2132,9 +2239,9 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
-            "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+            "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
             "dev": true,
             "license": "MIT"
         },
@@ -2216,9 +2323,9 @@
             "license": "MIT"
         },
         "node_modules/expect-type": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.0.tgz",
-            "integrity": "sha512-80F22aiJ3GLyVnS/B3HzgR6RelZVumzj9jkL0Rhz4h0xYbNW9PjlQz5h3J/SShErbXBc295vseR4/MIbVmUbeA==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+            "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -2255,6 +2362,23 @@
             "engines": {
                 "node": ">=8.6.0"
             }
+        },
+        "node_modules/fast-uri": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+            "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause"
         },
         "node_modules/fastq": {
             "version": "1.19.1",
@@ -2295,16 +2419,17 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-            "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -2471,9 +2596,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2581,13 +2706,13 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.16.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-            "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+            "version": "2.16.2",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+            "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "hasown": "^2.0.2"
+                "hasown": "^2.0.3"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -2737,31 +2862,18 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/loupe": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
-            "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+            "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
         },
         "node_modules/lz-string": {
             "version": "1.5.0",
@@ -2818,9 +2930,9 @@
             }
         },
         "node_modules/micromatch/node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2864,16 +2976,19 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
-            "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+            "version": "10.2.3",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.3.tgz",
+            "integrity": "sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==",
             "dev": true,
-            "license": "ISC",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "^5.0.2"
             },
             "engines": {
-                "node": "*"
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/mlly": {
@@ -2923,9 +3038,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.10",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.10.tgz",
-            "integrity": "sha512-vSJJTG+t/dIKAUhUDw/dLdZ9s//5OxcHqLaDWWrW4Cdq7o6tdLIczUkMXt2MBNmk6sJRZBZRXVixs7URY1CmIg==",
+            "version": "3.3.15",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+            "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
             "dev": true,
             "funding": [
                 {
@@ -3006,9 +3121,9 @@
             "license": "MIT"
         },
         "node_modules/pathval": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
-            "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+            "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3023,9 +3138,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3048,9 +3163,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.3",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-            "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+            "version": "8.5.16",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+            "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
             "dev": true,
             "funding": [
                 {
@@ -3068,7 +3183,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.8",
+                "nanoid": "^3.3.12",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -3173,9 +3288,9 @@
             }
         },
         "node_modules/readdirp/node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3217,13 +3332,14 @@
             }
         },
         "node_modules/resolve": {
-            "version": "1.22.10",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-            "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+            "version": "1.22.12",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+            "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "is-core-module": "^2.16.0",
+                "es-errors": "^1.3.0",
+                "is-core-module": "^2.16.1",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
             },
@@ -3249,13 +3365,13 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.36.0",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.36.0.tgz",
-            "integrity": "sha512-zwATAXNQxUcd40zgtQG0ZafcRK4g004WtEl7kbuhTWPvf07PsfohXl39jVUvPF7jvNAIkKPQ2XrsDlWuxBd++Q==",
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+            "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/estree": "1.0.6"
+                "@types/estree": "1.0.9"
             },
             "bin": {
                 "rollup": "dist/bin/rollup"
@@ -3265,25 +3381,31 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.36.0",
-                "@rollup/rollup-android-arm64": "4.36.0",
-                "@rollup/rollup-darwin-arm64": "4.36.0",
-                "@rollup/rollup-darwin-x64": "4.36.0",
-                "@rollup/rollup-freebsd-arm64": "4.36.0",
-                "@rollup/rollup-freebsd-x64": "4.36.0",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.36.0",
-                "@rollup/rollup-linux-arm-musleabihf": "4.36.0",
-                "@rollup/rollup-linux-arm64-gnu": "4.36.0",
-                "@rollup/rollup-linux-arm64-musl": "4.36.0",
-                "@rollup/rollup-linux-loongarch64-gnu": "4.36.0",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.36.0",
-                "@rollup/rollup-linux-riscv64-gnu": "4.36.0",
-                "@rollup/rollup-linux-s390x-gnu": "4.36.0",
-                "@rollup/rollup-linux-x64-gnu": "4.36.0",
-                "@rollup/rollup-linux-x64-musl": "4.36.0",
-                "@rollup/rollup-win32-arm64-msvc": "4.36.0",
-                "@rollup/rollup-win32-ia32-msvc": "4.36.0",
-                "@rollup/rollup-win32-x64-msvc": "4.36.0",
+                "@rollup/rollup-android-arm-eabi": "4.62.2",
+                "@rollup/rollup-android-arm64": "4.62.2",
+                "@rollup/rollup-darwin-arm64": "4.62.2",
+                "@rollup/rollup-darwin-x64": "4.62.2",
+                "@rollup/rollup-freebsd-arm64": "4.62.2",
+                "@rollup/rollup-freebsd-x64": "4.62.2",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+                "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+                "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+                "@rollup/rollup-linux-arm64-musl": "4.62.2",
+                "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+                "@rollup/rollup-linux-loong64-musl": "4.62.2",
+                "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+                "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+                "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+                "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+                "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+                "@rollup/rollup-linux-x64-gnu": "4.62.2",
+                "@rollup/rollup-linux-x64-musl": "4.62.2",
+                "@rollup/rollup-openbsd-x64": "4.62.2",
+                "@rollup/rollup-openharmony-arm64": "4.62.2",
+                "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+                "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+                "@rollup/rollup-win32-x64-gnu": "4.62.2",
+                "@rollup/rollup-win32-x64-msvc": "4.62.2",
                 "fsevents": "~2.3.2"
             }
         },
@@ -3339,14 +3461,11 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "dev": true,
             "license": "ISC",
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -3407,9 +3526,9 @@
             "license": "MIT"
         },
         "node_modules/std-env": {
-            "version": "3.8.1",
-            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.1.tgz",
-            "integrity": "sha512-vj5lIj3Mwf9D79hBkltk5qmkFI+biIKWS2IBxEyEU3AX1tUf7AoL8nSazCOiiqQsGKIq01SClsKEzweu34uwvA==",
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+            "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
             "dev": true,
             "license": "MIT"
         },
@@ -3436,18 +3555,25 @@
                 "node": ">=8"
             }
         },
-        "node_modules/strip-json-comments": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+        "node_modules/strip-literal": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+            "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
             "dev": true,
             "license": "MIT",
-            "engines": {
-                "node": ">=8"
+            "dependencies": {
+                "js-tokens": "^9.0.1"
             },
             "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "url": "https://github.com/sponsors/antfu"
             }
+        },
+        "node_modules/strip-literal/node_modules/js-tokens": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+            "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/supports-color": {
             "version": "8.1.1",
@@ -3536,9 +3662,9 @@
             }
         },
         "node_modules/tinypool": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
-            "integrity": "sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+            "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3556,9 +3682,9 @@
             }
         },
         "node_modules/tinyspy": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
-            "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+            "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3645,15 +3771,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/undici-types": {
-            "version": "6.20.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-            "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/universalify": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -3664,20 +3781,10 @@
                 "node": ">= 10.0.0"
             }
         },
-        "node_modules/uri-js": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "punycode": "^2.1.0"
-            }
-        },
         "node_modules/vite": {
-            "version": "6.3.5",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-            "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+            "version": "6.4.3",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+            "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3750,17 +3857,17 @@
             }
         },
         "node_modules/vite-node": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.0.9.tgz",
-            "integrity": "sha512-w3Gdx7jDcuT9cNn9jExXgOyKmf5UOTb6WMHz8LGAm54eS1Elf5OuBhCxl6zJxGhEeIkgsE1WbHuoL0mj/UXqXg==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+            "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "cac": "^6.7.14",
-                "debug": "^4.4.0",
-                "es-module-lexer": "^1.6.0",
+                "debug": "^4.4.1",
+                "es-module-lexer": "^1.7.0",
                 "pathe": "^2.0.3",
-                "vite": "^5.0.0 || ^6.0.0"
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
             },
             "bin": {
                 "vite-node": "vite-node.mjs"
@@ -3800,9 +3907,9 @@
             }
         },
         "node_modules/vite-plugin-static-copy": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.0.tgz",
-            "integrity": "sha512-LLKwhhHetGaCnWz4mas4qqjjguDka6/6b4+SeIohRroj8aCE7QTfiZECfPecslFQkWZ3HdQuq5kOPmWZjNYlKA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.2.tgz",
+            "integrity": "sha512-iwrrf+JupY4b9stBttRWzGHzZbeMjAHBhkrn67MNACXJVjEMRpCI10Q3AkxdBkl45IHaTfw/CNVevzQhP7yTwg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3820,31 +3927,34 @@
             }
         },
         "node_modules/vitest": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.0.9.tgz",
-            "integrity": "sha512-BbcFDqNyBlfSpATmTtXOAOj71RNKDDvjBM/uPfnxxVGrG+FSH2RQIwgeEngTaTkuU/h0ScFvf+tRcKfYXzBybQ==",
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+            "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/expect": "3.0.9",
-                "@vitest/mocker": "3.0.9",
-                "@vitest/pretty-format": "^3.0.9",
-                "@vitest/runner": "3.0.9",
-                "@vitest/snapshot": "3.0.9",
-                "@vitest/spy": "3.0.9",
-                "@vitest/utils": "3.0.9",
+                "@types/chai": "^5.2.2",
+                "@vitest/expect": "3.2.6",
+                "@vitest/mocker": "3.2.6",
+                "@vitest/pretty-format": "^3.2.6",
+                "@vitest/runner": "3.2.6",
+                "@vitest/snapshot": "3.2.6",
+                "@vitest/spy": "3.2.6",
+                "@vitest/utils": "3.2.6",
                 "chai": "^5.2.0",
-                "debug": "^4.4.0",
-                "expect-type": "^1.1.0",
+                "debug": "^4.4.1",
+                "expect-type": "^1.2.1",
                 "magic-string": "^0.30.17",
                 "pathe": "^2.0.3",
-                "std-env": "^3.8.0",
+                "picomatch": "^4.0.2",
+                "std-env": "^3.9.0",
                 "tinybench": "^2.9.0",
                 "tinyexec": "^0.3.2",
-                "tinypool": "^1.0.2",
+                "tinyglobby": "^0.2.14",
+                "tinypool": "^1.1.1",
                 "tinyrainbow": "^2.0.0",
-                "vite": "^5.0.0 || ^6.0.0",
-                "vite-node": "3.0.9",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+                "vite-node": "3.2.4",
                 "why-is-node-running": "^2.3.0"
             },
             "bin": {
@@ -3860,8 +3970,8 @@
                 "@edge-runtime/vm": "*",
                 "@types/debug": "^4.1.12",
                 "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-                "@vitest/browser": "3.0.9",
-                "@vitest/ui": "3.0.9",
+                "@vitest/browser": "3.2.6",
+                "@vitest/ui": "3.2.6",
                 "happy-dom": "*",
                 "jsdom": "*"
             },
@@ -3974,9 +4084,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.18.1",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-            "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4011,13 +4121,6 @@
             "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true,
-            "license": "ISC"
         }
     }
 }


### PR DESCRIPTION
## Resumo

Resolve os **20 alertas abertos** do Dependabot (npm), todos em `package-lock.json`, via `npm audit fix` — sem `--force`, respeitando semver, **zero breaking changes**.

> **Contexto:** todas as vulnerabilidades estavam em `devDependencies` e dependências transitivas. As dependências de runtime publicadas (`clusterize.js`, `fuse.js`) já estavam limpas — nenhum consumidor do pacote publicado estava exposto. O impacto era restrito à toolchain de build/teste.

## Principais atualizações

| Pacote | De → Para | Severidade | Tipo |
|---|---|---|---|
| vitest | 3.0.9 → 3.2.6 | **critical** | dev direta |
| form-data | 4.0.2 → 4.0.6 | **critical** | transitiva |
| vite | 6.3.5 → 6.4.3 | high | dev direta |
| lodash | 4.17.21 → 4.18.1 | high | transitiva |
| rollup | 4.36.0 → 4.59+ | high | transitiva |
| minimatch / picomatch | atualizadas | high | transitiva |
| vite-plugin-static-copy | 2.3.0 → 2.3.2 | medium | dev direta |

Também limpa alertas correlatos reportados pelo `npm audit` (ajv, brace-expansion, postcss, ws).

Apenas `package-lock.json` foi alterado — os ranges `^` do `package.json` já cobriam as versões corrigidas.

## Validação

- ✅ `npm audit` → **0 vulnerabilities**
- ✅ Testes → **39/39 passando** (vitest 3.2.6)
- ✅ Build → **OK** (vite 6.4.3, `.d.ts` + static-copy funcionando)

🤖 Generated with [Claude Code](https://claude.com/claude-code)