### PR TITLE
ci: OIDC trusted publishing + Node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
       - run: npm ci
       - run: npm test

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,6 +7,12 @@ on:
   repository_dispatch:
     types: [trigger-publish]
 
+# Required for OIDC Trusted Publishing (no long-lived NPM_TOKEN needed).
+# Also enables automatic npm provenance attestation.
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -17,13 +23,17 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org/'
+
+      # Trusted Publishing (OIDC) requires npm >= 11.5.1, newer than the
+      # version bundled with Node 22.
+      - run: npm install -g npm@latest
 
       - run: npm ci
 
       - run: npm run build
 
+      # No NODE_AUTH_TOKEN: authentication is handled via OIDC once the
+      # package's Trusted Publisher is configured on npmjs.com.
       - run: npm publish --access public --tag latest
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Objetivo

Eliminar a causa raiz da falha de publish da 0.3.5 (secret `NPM_TOKEN` expirado) e remover o aviso de deprecação do Node 20 nos runners.

## Mudanças

- **OIDC Trusted Publishing** no `npm-publish.yml`: remove a dependência do secret `NPM_TOKEN` (token de longa duração que expira). Autenticação passa a ser via OIDC do GitHub Actions, com **token efêmero por execução** — nunca mais quebra por expiração. Habilita também **provenance** automática no npm.
  - Adiciona `permissions: id-token: write`
  - Atualiza o npm para o mais recente (trusted publishing exige npm >= 11.5.1)
  - Remove o `env.NODE_AUTH_TOKEN`
- **Node 20 → 22** em `npm-publish.yml` e `ci.yml` (Node 20 está deprecado nos runners).

## ⚠️ Pré-requisito antes do merge

O Trusted Publishing só funciona depois de configurar o **Trusted Publisher** na página do pacote no npm. **Sem isso, o próximo publish falha.**

1. npmjs.com → pacote `@plantae-tech/plantae-filter` → **Settings** → **Trusted Publisher**
2. **GitHub Actions**, preenchendo:
   - **Organization or user:** `plantae-technologies`
   - **Repository:** `plantae-filter`
   - **Workflow filename:** `npm-publish.yml`
   - **Environment:** (em branco)
3. Salvar e **só então** fazer merge deste PR. Depois, o secret `NPM_TOKEN` pode ser removido (opcional).

## Validação

- YAML dos 3 workflows validado (parse OK).
- Sem mudança de comportamento além do bump de Node e do método de auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)