### PR TITLE
fix: correct GitHub org name in package.json URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,11 +41,11 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/plantae-tecnologies/plantae-filter"
+        "url": "https://github.com/plantae-technologies/plantae-filter"
     },
-    "homepage": "https://plantae-tecnologies.github.io/plantae-filter/",
+    "homepage": "https://plantae-technologies.github.io/plantae-filter/",
     "bugs": {
-        "url": "https://github.com/plantae-tecnologies/plantae-filter/issues"
+        "url": "https://github.com/plantae-technologies/plantae-filter/issues"
     },
     "devDependencies": {
         "@testing-library/dom": "^10.4.0",


### PR DESCRIPTION
Corrige `repository.url`, `homepage` e `bugs.url` que usavam o nome antigo/com typo do org (`plantae-tecnologies`, sem "h").

**Motivo:** a verificação de *provenance* do npm (OIDC trusted publishing) rejeita o publish com `E422` porque o `repository.url` precisa bater com o repo real (`plantae-technologies`) gravado na provenance. Foi exatamente o que quebrou a tentativa de publish da 0.3.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)